### PR TITLE
Require campaigns filter to Reassign All in Message Review

### DIFF
--- a/src/components/IncomingMessageActions.jsx
+++ b/src/components/IncomingMessageActions.jsx
@@ -86,11 +86,6 @@ class IncomingMessageActions extends Component {
   }
 
   render() {
-    const showCreateCampaign =
-      this.props.conversationCount &&
-      document.location.search &&
-      /=/.test(document.location.search);
-
     const texterNodes = !this.props.people
       ? []
       : this.props.people.map(user => {
@@ -102,15 +97,19 @@ class IncomingMessageActions extends Component {
       return left.text.localeCompare(right.text, "en", { sensitivity: "base" });
     });
 
+    const hasCampaignsFilter =
+      this.props.campaignsFilter &&
+      (this.props.campaignsFilter.campaignIds || []).length;
+
     const confirmDialogActions = [
       <FlatButton
         label="Cancel"
-        primary={true}
+        primary
         onClick={this.handleConfirmDialogCancel}
       />,
       <FlatButton
         label="Reassign"
-        primary={true}
+        primary
         onClick={this.handleConfirmDialogReassign}
       />
     ];
@@ -151,7 +150,7 @@ class IncomingMessageActions extends Component {
                 disabled={!this.state.reassignTo}
               />
             </div>
-            {this.props.conversationCount ? (
+            {this.props.conversationCount && hasCampaignsFilter ? (
               <div className={css(styles.flexColumn)}>
                 <FlatButton
                   label={`Reassign all ${this.props.conversationCount} matching`}
@@ -159,13 +158,15 @@ class IncomingMessageActions extends Component {
                   disabled={!this.state.reassignTo}
                 />
               </div>
+            ) : !hasCampaignsFilter ? (
+              "Select campaign(s) to reassign all"
             ) : (
               ""
             )}
             <Dialog
               actions={confirmDialogActions}
               open={this.state.confirmDialogOpen}
-              modal={true}
+              modal
               onRequestClose={this.handleConfirmDialogCancel}
             >
               {`Reassign all ${this.props.conversationCount} matching conversations?`}
@@ -181,7 +182,9 @@ IncomingMessageActions.propTypes = {
   people: type.array,
   onReassignRequested: type.func.isRequired,
   onReassignAllMatchingRequested: type.func.isRequired,
-  conversationCount: type.number
+  conversationCount: type.number,
+  campaignsFilter: type.object,
+  texters: type.array
 };
 
 export default IncomingMessageActions;

--- a/src/containers/AdminIncomingMessageList.jsx
+++ b/src/containers/AdminIncomingMessageList.jsx
@@ -103,14 +103,14 @@ export class AdminIncomingMessageList extends Component {
           query.tags = selectedTags.join(",");
         }
       }
-      //default false
+      // default false
       if (nextState.includeArchivedCampaigns) {
         query.archived = 1;
       }
       if (nextState.includeOptedOutConversations) {
         query.optedOut = 1;
       }
-      //default true
+      // default true
       if (!nextState.includeActiveCampaigns) {
         query.active = 0;
       }
@@ -205,7 +205,7 @@ export class AdminIncomingMessageList extends Component {
     await this.props.mutations.bulkReassignCampaignContacts(
       this.props.params.organizationId,
       newTexterUserId,
-      this.state.campaignsFilter || {},
+      this.state.campaignsFilter,
       this.state.assignmentsFilter || {},
       this.state.contactsFilter || {},
       this.state.messageTextFilter || null
@@ -461,6 +461,7 @@ export class AdminIncomingMessageList extends Component {
               this.handleReassignAllMatchingRequested
             }
             conversationCount={this.state.conversationCount}
+            campaignsFilter={this.state.campaignsFilter}
           />
           <br />
           <IncomingMessageList


### PR DESCRIPTION
We had a snafu where someone reassigned all for all campaigns requiring a lot of work to fix. This really shouldn't be possible, so it was requested that we at least require a campaign filter to be selected to reassign all.

Convo: https://wfp4themany.slack.com/archives/G79S2RTUM/p1601436321032600