### PR TITLE
option to send message send error details in email

### DIFF
--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -7,13 +7,52 @@ import { jobRunner } from "../../../extensions/job-runners";
 import { Tasks } from "../../../workers/tasks";
 import { updateContactTags } from "./updateContactTags";
 
+import { sendEmail } from "../../mail";
+import { log } from "../../../lib";
+
 const JOBS_SAME_PROCESS = !!(
   process.env.JOBS_SAME_PROCESS || global.JOBS_SAME_PROCESS
 );
 
-const newError = (message, code) => {
+const newError = (message, code, details = {}) => {
   const err = new GraphQLError(message);
   err.code = code;
+  if (process.env.DEBUGGING_EMAILS) {
+    sendEmail({
+      to: process.env.DEBUGGING_EMAILS.split(","),
+      subject: `Spoke Send Message Error`,
+      html: `
+        <body>
+          <div><b>ERROR CODE: ${code}</b></div>
+          <div>ERROR MESSAGE: ${message}</div>
+          <br />
+          <div>DETAILS</div>
+          <pre>${JSON.stringify(
+            {
+              ...details.message,
+              campaignContactId: details.campaignContactId,
+              user: details.user
+                ? {
+                    id: details.user.id,
+                    name: `${details.user.first_name} ${details.user.last_name}`
+                  }
+                : undefined,
+              campaign: details.campaign
+                ? {
+                    id: details.campaign.id,
+                    title: details.campaign.title,
+                    organizationId: details.campaign.organization_id
+                  }
+                : undefined
+            },
+            null,
+            2
+          )}
+          </pre>
+        </body>
+      `
+    }).catch(emailErr => log.debug(emailErr));
+  }
   return err;
 };
 
@@ -25,12 +64,18 @@ export const sendMessage = async (
   // contact is mutated, so we don't use a loader
   let contact = await cacheableData.campaignContact.load(campaignContactId);
   const campaign = await loaders.campaign.load(contact.campaign_id);
+
   if (
     contact.assignment_id !== parseInt(message.assignmentId) ||
     campaign.is_archived
   ) {
     console.error("Error: assignment changed");
-    throw newError("Your assignment has changed", "SENDERR_ASSIGNMENTCHANGED");
+    throw newError("Your assignment has changed", "SENDERR_ASSIGNMENTCHANGED", {
+      message,
+      campaignContactId,
+      user,
+      campaign
+    });
   }
   const organization = await loaders.organization.load(
     campaign.organization_id
@@ -45,7 +90,13 @@ export const sendMessage = async (
   if (optOut) {
     throw newError(
       "Skipped sending because this contact was already opted out",
-      "SENDERR_OPTEDOUT"
+      "SENDERR_OPTEDOUT",
+      {
+        message,
+        campaignContactId,
+        user,
+        campaign
+      }
     );
   }
   // const zipData = await r.table('zip_code')
@@ -68,7 +119,12 @@ export const sendMessage = async (
   const { text } = message;
 
   if (text.length > (process.env.MAX_MESSAGE_LENGTH || 99999)) {
-    throw newError("Message was longer than the limit", "SENDERR_MAXLEN");
+    throw newError("Message was longer than the limit", "SENDERR_MAXLEN", {
+      message,
+      campaignContactId,
+      user,
+      campaign
+    });
   }
 
   const replaceCurlyApostrophes = rawText =>
@@ -102,7 +158,13 @@ export const sendMessage = async (
   if (sendBeforeDate && sendBeforeDate <= Date.now()) {
     throw newError(
       "Outside permitted texting time for this recipient",
-      "SENDERR_OFFHOURS"
+      "SENDERR_OFFHOURS",
+      {
+        message,
+        campaignContactId,
+        user,
+        campaign
+      }
     );
   }
   const serviceName =
@@ -139,7 +201,13 @@ export const sendMessage = async (
   if (!saveResult.message) {
     throw newError(
       `Message send error ${saveResult.texterError || ""}`,
-      "SENDERR_SAVEFAIL"
+      "SENDERR_SAVEFAIL",
+      {
+        message,
+        campaignContactId,
+        user,
+        campaign
+      }
     );
   }
   contact.message_status = saveResult.contactStatus;

--- a/src/server/mail.js
+++ b/src/server/mail.js
@@ -27,18 +27,23 @@ const nodeMailerConfig = {
 const sender =
   getConfig("MAILGUN_API_KEY") && getConfig("MAILGUN_DOMAIN")
     ? {
-        sendMail: ({ from, to, subject, replyTo, text }) =>
-          mailgun.messages().send({
-            from,
-            "h:Reply-To": replyTo,
-            to,
-            subject,
-            text
-          })
+        sendMail: ({ from, to, subject, replyTo, text, html }) =>
+          mailgun.messages().send(
+            {
+              from,
+              "h:Reply-To": replyTo,
+              to,
+              subject,
+              ...(html ? { html } : { text })
+            },
+            err => {
+              if (err) log.debug(err.message);
+            }
+          )
       }
     : nodemailer.createTransport(nodeMailerConfig);
 
-export const sendEmail = async ({ to, subject, text, replyTo }) => {
+export const sendEmail = async ({ to, subject, text, html, replyTo }) => {
   log.info(`Sending e-mail to ${to} with subject ${subject}.`);
 
   if (process.env.NODE_ENV === "development") {
@@ -50,7 +55,8 @@ export const sendEmail = async ({ to, subject, text, replyTo }) => {
     from: getConfig("EMAIL_FROM"),
     to,
     subject,
-    text
+    text,
+    html
   };
 
   if (replyTo) {


### PR DESCRIPTION
## Description

It's currently extremely difficult to divine details of a message send error, so I'm sending them in an email if a new env variable called `DEBUGGING_EMAILS` is set to contain one or more email address.

An example of the email:
<img width="1000" alt="Screen Shot 2020-10-07 at 6 35 21 PM" src="https://user-images.githubusercontent.com/13374656/95405220-14c90100-08cc-11eb-9a56-16e1900a2a3f.png">
