### PR TITLE
Export combine same questions

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -660,6 +660,7 @@ export async function exportCampaign(job) {
   const payload = JSON.parse(job.payload);
   const id = job.campaign_id;
   const campaign = await Campaign.get(id);
+  const organization = await Organization.get(campaign.organization_id);
   const requester = payload.requester;
   const user = await User.get(requester);
   const allQuestions = {};
@@ -667,6 +668,12 @@ export async function exportCampaign(job) {
   const interactionSteps = await r
     .table("interaction_step")
     .getAll(id, { index: "campaign_id" });
+
+  const combineSameQuestions = getConfig(
+    "EXPORT_COMBINE_SAME_QUESTIONS",
+    organization,
+    { truthy: 1 }
+  );
 
   interactionSteps.forEach(step => {
     if (!step.question || step.question.trim() === "") {
@@ -679,7 +686,8 @@ export async function exportCampaign(job) {
       questionCount[step.question] = 0;
     }
     const currentCount = questionCount[step.question];
-    if (currentCount > 0) {
+
+    if (currentCount > 0 && !combineSameQuestions) {
       allQuestions[step.id] = `${step.question}_${currentCount}`;
     } else {
       allQuestions[step.id] = step.question;
@@ -787,7 +795,17 @@ export async function exportCampaign(job) {
           }
         });
 
-        contactRow[`question[${allQuestions[stepId]}]`] = value;
+        if (
+          value !== "" &&
+          combineSameQuestions &&
+          contactRow[`question[${allQuestions[stepId]}]`] &&
+          contactRow[`question[${allQuestions[stepId]}]`] !== value
+        ) {
+          // join multiple different answers, otherwise combine answers too
+          contactRow[`question[${allQuestions[stepId]}]`] += `, ${value}`;
+        } else {
+          contactRow[`question[${allQuestions[stepId]}]`] = value;
+        }
       });
 
       return contactRow;
@@ -828,6 +846,7 @@ export async function exportCampaign(job) {
         "getObject",
         params
       );
+
       await sendEmail({
         to: user.email,
         subject: `Export ready for ${campaign.title}`,


### PR DESCRIPTION
## Description

Spoke question design is a bit clunky and doesn't allow re-using the same question when creating complex scripts with nesting of the "same" question, and folks often complain about wrangling numerous columns for the same question when doing exports. This allows the optional use of `EXPORT_COMBINE_SAME_QUESTIONS` to combine interaction steps with exactly the same `question` text, until we have a more robust front-end solution implemented.