### PR TITLE
Campaign phones area code selection UI improvements

### DIFF
--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -74,6 +74,12 @@ export const schema = gql`
     count: Int!
   }
 
+  type CampaignContactsAreaCodeCount {
+    areaCode: String!
+    state: String!
+    count: Int!
+  }
+
   type Campaign {
     id: ID
     organization: Organization
@@ -93,6 +99,7 @@ export const schema = gql`
     interactionSteps: [InteractionStep]
     contacts: [CampaignContact]
     contactsCount: Int
+    contactsAreaCodeCounts: [CampaignContactsAreaCodeCount]
     hasUnassignedContacts: Boolean
     hasUnassignedContactsForTexter: Boolean
     hasUnsentInitialMessages: Boolean

--- a/src/components/CampaignContactsChoiceForm.jsx
+++ b/src/components/CampaignContactsChoiceForm.jsx
@@ -72,13 +72,18 @@ export class CampaignContactsChoiceForm extends React.Component {
 
   handleChange(contactData) {
     this.props.onChange({
-      contactData: contactData,
+      contactData,
       ingestMethod: this.getCurrentMethod().name
     });
   }
 
   render() {
-    const { ingestMethodChoices, pastIngestMethod } = this.props;
+    const {
+      maxNumbersPerCampaign,
+      contactsPerPhoneNumber,
+      ingestMethodChoices,
+      pastIngestMethod
+    } = this.props;
     const ingestMethod = this.getCurrentMethod();
     const ingestMethodName = ingestMethod && ingestMethod.name;
     const lastResult =
@@ -86,9 +91,33 @@ export class CampaignContactsChoiceForm extends React.Component {
         ? pastIngestMethod
         : null;
     const IngestComponent = components[ingestMethodName];
+
     return (
       <div>
         <CampaignFormSectionHeading title="Who are you contacting?" />
+
+        {contactsPerPhoneNumber && maxNumbersPerCampaign && (
+          <div
+            style={{
+              marginBottom: 10,
+              fontSize: 17,
+              color: theme.colors.darkBlue
+            }}
+          >
+            <div>
+              You can only upload a max of{" "}
+              {Number(
+                contactsPerPhoneNumber * maxNumbersPerCampaign
+              ).toLocaleString()}{" "}
+              contacts per campaign.
+            </div>
+            <div>
+              Each campaign can be assigned {maxNumbersPerCampaign} numbers max
+              with {contactsPerPhoneNumber} contacts per phone.
+            </div>
+          </div>
+        )}
+
         <div>
           {!this.props.contactsCount ? (
             ""
@@ -151,6 +180,8 @@ export class CampaignContactsChoiceForm extends React.Component {
               clientChoiceData={ingestMethod && ingestMethod.clientChoiceData}
               lastResult={lastResult}
               jobResultMessage={null}
+              contactsPerPhoneNumber={contactsPerPhoneNumber}
+              maxNumbersPerCampaign={maxNumbersPerCampaign}
             />
           )}
         </div>
@@ -173,7 +204,9 @@ CampaignContactsChoiceForm.propTypes = {
   jobResultMessage: type.string,
   ingestMethodChoices: type.array.isRequired,
   pastIngestMethod: type.object,
-  contactsCount: type.number
+  contactsCount: type.number,
+  maxNumbersPerCampaign: type.number,
+  contactsPerPhoneNumber: type.number
 };
 
 export default withRouter(CampaignContactsChoiceForm);

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -565,7 +565,7 @@ export class AdminCampaignEdit extends React.Component {
           isStarted: this.props.campaignData.campaign.isStarted,
           phoneNumberCounts: this.props.organizationData.organization
             .phoneNumberCounts,
-          contactsCount: this.state.campaignFormValues.contactsCount,
+          contactsCount: this.props.campaignData.campaign.contactsCount,
           contactsAreaCodeCounts: this.props.campaignData.campaign
             .contactsAreaCodeCounts,
           inventoryCounts: this.props.campaignData.campaign

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -265,7 +265,6 @@ export class AdminCampaignEdit extends React.Component {
   }
 
   handleChange = formValues => {
-    console.log("handleChange", formValues);
     this.setState({
       campaignFormValues: {
         ...this.state.campaignFormValues,
@@ -294,7 +293,9 @@ export class AdminCampaignEdit extends React.Component {
         // the section we just saved.
         this.props.campaignData.refetch();
         // hack to update phone counts, probably should make phone reservation its own mutation
-        if (this.props.organizationData.campaignPhoneNumbersEnabled) {
+        if (
+          this.props.organizationData.organization.campaignPhoneNumbersEnabled
+        ) {
           this.props.organizationData.refetch();
         }
       }
@@ -334,7 +335,7 @@ export class AdminCampaignEdit extends React.Component {
         newCampaign.interactionSteps = makeTree(newCampaign.interactionSteps);
       }
 
-      return await this.props.mutations.editCampaign(
+      await this.props.mutations.editCampaign(
         this.props.campaignData.campaign.id,
         newCampaign
       );
@@ -545,15 +546,16 @@ export class AdminCampaignEdit extends React.Component {
           return numbersReserved >= numbersNeeded;
         },
         blocksStarting: true,
-        expandAfterCampaignStarts: false,
+        expandAfterCampaignStarts: true,
         expandableBySuperVolunteers: false,
         extraProps: {
-          contactsPerPhoneNumber: contactsPerPhoneNumber,
+          contactsPerPhoneNumber,
           isStarted: this.props.campaignData.campaign.isStarted,
-          availablePhoneNumbers: this.props.organizationData.organization.phoneNumberCounts.filter(
-            c => c.availableCount
-          ),
-          contactsCount: this.state.campaignFormValues.contactsCount
+          phoneNumberCounts: this.props.organizationData.organization
+            .phoneNumberCounts,
+          contactsCount: this.state.campaignFormValues.contactsCount,
+          inventoryCounts: this.props.campaignData.campaign
+            .inventoryPhoneNumberCounts
         }
       });
     }
@@ -637,7 +639,7 @@ export class AdminCampaignEdit extends React.Component {
       <ContentComponent
         onChange={this.handleChange}
         formValues={formValues}
-        saveLabel={this.isNew() ? "Save and goto next section" : "Save"}
+        saveLabel={this.isNew() ? "Save and go to next section" : "Save"}
         saveDisabled={shouldDisable}
         ensureComplete={this.props.campaignData.campaign.isStarted}
         onSubmit={this.handleSubmit}
@@ -972,6 +974,7 @@ const queries = {
           }
           phoneNumberCounts {
             areaCode
+            state
             availableCount
             allocatedCount
           }

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -110,6 +110,11 @@ const campaignInfoFragment = `
     areaCode
     count
   }
+  contactsAreaCodeCounts {
+    areaCode
+    state
+    count
+  }
 `;
 
 export const campaignDataQuery = gql`query getCampaign($campaignId: String!) {
@@ -561,6 +566,8 @@ export class AdminCampaignEdit extends React.Component {
           phoneNumberCounts: this.props.organizationData.organization
             .phoneNumberCounts,
           contactsCount: this.state.campaignFormValues.contactsCount,
+          contactsAreaCodeCounts: this.props.campaignData.campaign
+            .contactsAreaCodeCounts,
           inventoryCounts: this.props.campaignData.campaign
             .inventoryPhoneNumberCounts
         }

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -410,7 +410,14 @@ export class AdminCampaignEdit extends React.Component {
               pendingJobs
                 .filter(job => /ingest/.test(job.jobType))
                 .reverse()[0] || {}
-            ).resultMessage || ""
+            ).resultMessage || "",
+          ...(this.props.organizationData.organization
+            .campaignPhoneNumbersEnabled
+            ? {
+                contactsPerPhoneNumber: window.CONTACTS_PER_PHONE_NUMBER,
+                maxNumbersPerCampaign: 400
+              }
+            : {})
         }
       },
       {

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -200,6 +200,9 @@ class AdminCampaignStats extends React.Component {
           {campaign.isArchived ? (
             <div className={css(styles.archivedBanner)}>
               This campaign is archived
+              {campaign.isArchivedPermanently
+                ? " and its phone numbers have been released"
+                : ""}
             </div>
           ) : (
             ""
@@ -297,6 +300,7 @@ class AdminCampaignStats extends React.Component {
                         campaign.useOwnMessagingService ? (
                           <RaisedButton
                             {...dataTest("messagingService")}
+                            disabled={campaign.isArchivedPermanently}
                             onTouchTap={() =>
                               this.props.router.push(
                                 `/admin/${organizationId}/campaigns/${campaignId}/messaging-service`
@@ -307,6 +311,7 @@ class AdminCampaignStats extends React.Component {
                         ) : null,
                         showReleaseNumbers ? (
                           <RaisedButton
+                            disabled={campaign.isArchivedPermanently}
                             onTouchTap={async () =>
                               this.props.mutations.releaseCampaignNumbers(
                                 campaignId

--- a/src/extensions/contact-loaders/csv-upload/react-component.js
+++ b/src/extensions/contact-loaders/csv-upload/react-component.js
@@ -79,6 +79,12 @@ export class CampaignContactsForm extends React.Component {
   };
 
   handleUpload = event => {
+    const { contactsPerPhoneNumber, maxNumbersPerCampaign } = this.props;
+    let maxContacts = null;
+    if (contactsPerPhoneNumber && maxNumbersPerCampaign) {
+      maxContacts = contactsPerPhoneNumber * maxNumbersPerCampaign;
+    }
+
     event.preventDefault();
     const file = event.target.files[0];
     this.setState({ uploading: true }, () => {
@@ -89,6 +95,12 @@ export class CampaignContactsForm extends React.Component {
             this.handleUploadError(error);
           } else if (contacts.length === 0) {
             this.handleUploadError("Upload at least one contact");
+          } else if (maxContacts && contacts.length > maxContacts) {
+            this.handleUploadError(
+              `You can only upload ${Number(
+                maxContacts
+              ).toLocaleString()} contacts max – your file contains ${contacts.length.toLocaleString()}.`
+            );
           } else if (contacts.length > 0) {
             this.handleUploadSuccess(validationStats, contacts, customFields);
           }
@@ -135,6 +147,7 @@ export class CampaignContactsForm extends React.Component {
     if (!contactsCount) {
       return "";
     }
+
     return (
       <List>
         <Subheader>Uploaded</Subheader>
@@ -296,5 +309,8 @@ CampaignContactsForm.propTypes = {
   saveLabel: type.string,
 
   clientChoiceData: type.string,
-  jobResultMessage: type.string
+  jobResultMessage: type.string,
+
+  maxNumbersPerCampaign: type.number,
+  contactsPerPhoneNumber: type.number
 };


### PR DESCRIPTION
## Description

The existing implementation only allows you to select an area code and it would assign all available phones with no ability to choose how many. These UI improvements allow more granular control over which area codes folks are assigning to a campaign in an intuitive way. 

Alternatively (and probably the recommended to use by default) – there's an Auto-Reserve button that will look for available area codes based first on exact matches in the uploaded contacts list, then matching state, finally randomly assigning the rest.

Note, this also removes the arbitrary "3 area codes per campaign" limitation. If there's actually a good reason for this, maybe we can add it back as a config var?

![campaign-phones](https://user-images.githubusercontent.com/13374656/95691230-780ba980-0bd2-11eb-8cd0-696f3629f26f.gif)

In the contacts section I added a pre-upload warning message + error on contact upload (for now, only CSV loader) if more than max allowable contacts as defined by `CONTACTS_PER_PHONE_NUMBER`.

![Screen Shot 2020-10-10 at 9 21 13 PM](https://user-images.githubusercontent.com/13374656/95670329-8e682580-0b3e-11eb-9fbb-c8ad45b85069.png)









