### PR TITLE
Option to retain Campaign Phones Messaging Service upon phones release

### DIFF
--- a/src/server/api/mutations/releaseCampaignNumbers.js
+++ b/src/server/api/mutations/releaseCampaignNumbers.js
@@ -33,10 +33,24 @@ export const releaseCampaignNumbers = async (_, { campaignId }, { user }) => {
   }
 
   if (service === "twilio") {
-    await twilio.deleteMessagingService(
+    const shouldRetainServices = getConfig(
+      "CAMPAIGN_PHONES_RETAIN_MESSAGING_SERVICES",
       organization,
-      campaign.messageservice_sid
+      { truthy: 1 }
     );
+
+    if (shouldRetainServices) {
+      // retain messaging services for analytics, just clear phones
+      await twilio.clearMessagingServicePhones(
+        organization,
+        campaign.messageservice_sid
+      );
+    } else {
+      await twilio.deleteMessagingService(
+        organization,
+        campaign.messageservice_sid
+      );
+    }
   }
 
   await r


### PR DESCRIPTION
## Description

It's either difficult or impossible to report on messaging service stats in Twilio once they're deleted, so it's probably best not to straight-up delete them, just "delete" (aka release) the numbers from them.
