### PR TITLE
Fetch Todos even with no / only opted-out contacts

### DIFF
--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -280,22 +280,18 @@ export const resolvers = {
         return await query.select(fields);
       } else {
         query
-          .leftJoin(
-            "campaign_contact",
-            "campaign_contact.assignment_id",
-            "assignment.id"
-          )
+          .leftOuterJoin("campaign_contact", function() {
+            this.on("campaign_contact.assignment_id", "assignment.id").andOn(
+              "campaign_contact.is_opted_out",
+              r.knex.raw("?", [false])
+            );
+            // https://github.com/knex/knex/issues/1003#issuecomment-287302118
+          })
           .groupBy(
             ...fields,
             "campaign_contact.timezone_offset",
             "campaign_contact.message_status"
           )
-          .where(function() {
-            // we need to allow null for empty assignments like dynamic assignment
-            this.where("campaign_contact.is_opted_out", false).orWhereNull(
-              "campaign_contact.is_opted_out"
-            );
-          })
           .select(
             ...fields,
             "campaign_contact.timezone_offset",

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -776,8 +776,10 @@ export async function exportCampaign(job) {
         "contact[messageStatus]": contact.message_status,
         "contact[errorCode]": contact.error_code,
         "contact[external_id]": contact.external_id,
-        "contact[tags]": tags.length > 0 ? tags.map(tag => tag.name) : null
+        "contact[tags]":
+          tags.length > 0 ? tags.map(tag => tag.name).join(" | ") : ""
       };
+
       const customFields = JSON.parse(contact.custom_fields);
       Object.keys(customFields).forEach(fieldName => {
         contactRow[`contact[${fieldName}]`] = customFields[fieldName];


### PR DESCRIPTION
The main question is: do new dynamic assignments not have any contacts? 

Anyway, the where statement that had exists was actually filtering out assignments that only had opted-out contacts, and we needed these to still be fetched if they have feedback. If the spirit was that we should always fetch todos even if they have no contacts / only opted-out contacts, this is fine. If we don't want to do this, we need to rework the query a bit.